### PR TITLE
Add wezterm config

### DIFF
--- a/config/lsyncd/wsl.lua
+++ b/config/lsyncd/wsl.lua
@@ -1,10 +1,15 @@
 local xdg_config_home = os.getenv('XDG_CONFIG_HOME') or '/home/hexin/.config'
+local user_profile = os.getenv('USERPROFILE') or '/mnt/c/Users/Hexin'
 local appdata = os.getenv('APPDATA') or '/mnt/c/Users/Hexin/AppData/Roaming'
 
 local transitions = {
   {
     source = ('%s/alacritty/'):format(xdg_config_home),
     target = ('%s/alacritty/'):format(appdata),
+  },
+  {
+    source = ('%s/wezterm/'):format(xdg_config_home),
+    target = ('%s/.config/wezterm/'):format(user_profile),
   },
 }
 

--- a/config/wezterm/appearance.lua
+++ b/config/wezterm/appearance.lua
@@ -1,0 +1,38 @@
+local wezterm = require('wezterm')
+
+local M = {}
+
+function M.apply(config)
+  config.initial_rows = 46
+  config.initial_cols = 160
+
+  config.color_scheme = 'Tomorrow Night Eighties'
+
+  config.font = wezterm.font('HackGen Console NF')
+  config.font_size = 11
+
+  config.enable_tab_bar = false
+
+  config.animation_fps = 1
+  config.cursor_blink_ease_in = 'Constant'
+  config.cursor_blink_ease_out = 'Constant'
+
+  config.ui_key_cap_rendering = 'WindowsSymbols'
+
+  config.window_decorations = 'RESIZE'
+  config.window_padding = {
+    left = 0,
+    right = 0,
+    top = 0,
+    bottom = 0,
+  }
+
+  wezterm.on('gui-startup', function (cmd)
+    local _, _, window = wezterm.mux.spawn_window(cmd or {})
+
+    local gui_window = window:gui_window()
+    gui_window:set_position(0, 0)
+  end)
+end
+
+return M

--- a/config/wezterm/keys.lua
+++ b/config/wezterm/keys.lua
@@ -1,0 +1,22 @@
+local wezterm = require('wezterm')
+
+local M = {}
+
+function M.apply(config)
+  config.keys = {
+    {
+      key = 'k',
+      mods = 'CTRL | SHIFT',
+      action = wezterm.action.ShowDebugOverlay,
+    },
+    {
+      key = '^',
+      mods = 'CTRL',
+      action = wezterm.action.DisableDefaultAssignment,
+    },
+  }
+config.debug_key_events = true
+end
+
+
+return M

--- a/config/wezterm/wezterm.lua
+++ b/config/wezterm/wezterm.lua
@@ -1,0 +1,28 @@
+local wezterm = require('wezterm')
+local appearance = require('appearance')
+local keys = require('keys')
+
+local config = wezterm.config_builder()
+
+config.automatically_reload_config = true
+
+config.font = wezterm.font('HackGen Console NF')
+config.font_size = 11
+config.check_for_updates = true
+
+config.default_prog = {
+  'C:/Windows/system32/wsl.exe',
+  '--cd',
+  '~',
+  '--distribution',
+  'arch',
+  '--exec',
+  '/bin/zsh',
+  '-c',
+  'tmux new -A && exec zsh -i',
+}
+
+appearance.apply(config)
+keys.apply(config)
+
+return config

--- a/install
+++ b/install
@@ -57,6 +57,7 @@ install_dotfiels() {
   make_symlink tmux $XDG_CONFIG_HOME/tmux
   make_symlink npm $XDG_CONFIG_HOME/npm
   make_symlink alacritty $XDG_CONFIG_HOME/alacritty
+  make_symlink wezterm $XDG_CONFIG_HOME/wezterm
   make_symlink lsyncd $XDG_CONFIG_HOME/lsyncd
   make_symlink systemd/user $XDG_CONFIG_HOME/systemd/user
 }


### PR DESCRIPTION
wezterm has some issues

- the Windows native snap or PowerToys Fancy Zones cannot move or resize when it is borderless by `config.window_decoration = 'NONE'`
- sixel is not available in Windows
  Using `wezterm ssh` makes it available, but this doesn't set environment variables related to WSL such as `PATH` or what is specified by `WSLENV`